### PR TITLE
feat: migrate from AWS SDK v2 to v3

### DIFF
--- a/db/persist.js
+++ b/db/persist.js
@@ -6,11 +6,17 @@
  * @onenote_section_count {String} local storage contents
  */
 
-const AWS = require('aws-sdk')
-AWS.config.update({ region: process.env.REGION })
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb')
+const { DynamoDBDocumentClient, GetCommand, UpdateCommand } = require('@aws-sdk/lib-dynamodb')
 
-const documentClient = new AWS.DynamoDB.DocumentClient({
-  apiVersion: '2012-10-08'
+const client = new DynamoDBClient({
+  region: process.env.REGION
+})
+
+const documentClient = DynamoDBDocumentClient.from(client, {
+  marshallOptions: {
+    removeUndefinedValues: true // Maintain v2 behavior
+  }
 })
 
 /**
@@ -31,7 +37,7 @@ async function getItem(itemName, parse = false) {
   }
 
   try {
-    const data = await documentClient.get(params).promise()
+    const data = await documentClient.send(new GetCommand(params))
     
     // Check if item exists and has the requested attribute
     if (!data.Item || data.Item[itemName] === undefined) {
@@ -73,7 +79,7 @@ async function setItem(itemName, data) {
   }
 
   try {
-    const result = await documentClient.update(params).promise()
+    const result = await documentClient.send(new UpdateCommand(params))
     return result
   } catch (err) {
     console.error(`Error setting db item: '${itemName}'`)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "author": "Byron Buckley",
   "license": "ISC",
   "devDependencies": {
-    "aws-sdk": "^2.1379.0",
+    "@aws-sdk/client-dynamodb": "^3.445.0",
+    "@aws-sdk/lib-dynamodb": "^3.445.0",
     "copy-webpack-plugin": "^11.0.0",
     "eslint": "^8.41.0",
     "eslint-config-prettier": "^8.8.0",


### PR DESCRIPTION
This PR migrates the notifyer-cron application from AWS SDK v2 to v3 following the specifications in `.kiro/specs/aws-sdk-v3-migration`.

## Changes
- Replace `aws-sdk` v2 with modular `@aws-sdk/client-dynamodb` and `@aws-sdk/lib-dynamodb` packages
- Update `db/persist.js` to use DynamoDBClient and DynamoDBDocumentClient with command pattern
- Configure marshallOptions.removeUndefinedValues to maintain v2 behavior

## Benefits
- Expected bundle size reduction from ~93.6MB to ~17MB
- Improved Lambda cold start performance
- Modular architecture with tree-shaking support
- Continued security updates and AWS service compatibility

Resolves #39

Generated with [Claude Code](https://claude.ai/code)